### PR TITLE
Renomeia campo para evitar ambiguidade

### DIFF
--- a/src/resources/B237/remessa/cnab400/Registro1.php
+++ b/src/resources/B237/remessa/cnab400/Registro1.php
@@ -69,7 +69,7 @@ class Registro1 extends Generico1
             'default'=>' ',
             'tipo'=>'alfa',
             'required'=>true),
-        'codigo_banco'=>array(
+        'codigo_banco_debito'=>array(
             'tamanho'=>3,
             'default'=>'0',
             'tipo'=>'int',


### PR DESCRIPTION
Esse campo, na realidade, serve para uso com débito automático