### PR TITLE
Removido fator cnab 400 sicredi nosso_numero

### DIFF
--- a/src/resources/B748/remessa/cnab400/Registro1.php
+++ b/src/resources/B748/remessa/cnab400/Registro1.php
@@ -302,7 +302,7 @@ class Registro1 extends Generico1 {
                         . str_pad(RemessaAbstract::$entryData['codigo_beneficiario'], 5, 0, STR_PAD_LEFT)
                         . str_pad(strftime("%y", strtotime($this->entryData['data_emissao'])), 2, 0, STR_PAD_LEFT)
                         . 2
-                        . str_pad($value, 5, 0, STR_PAD_LEFT), 7);
+                        . str_pad($value, 5, 0, STR_PAD_LEFT));
         $this->data['nosso_numero'] = strftime("%y", strtotime($this->entryData['data_emissao'])) . 2 . str_pad($value, 5, 0, STR_PAD_LEFT) . $modulo11['digito'];
     }
 


### PR DESCRIPTION
Na função set_nosso_numero é informado a base 7 como geração do nosso numero sicredi
entretanto o correto é a base 9.

Como por **default** é inserido o 9, apenas removi da chamada 