### PR TITLE
Ajuste de espécies da Sicredi - Especie.php

### DIFF
--- a/src/Especie.php
+++ b/src/Especie.php
@@ -141,8 +141,8 @@ class Especie {
         $this->sicredi['G'] = array('abr' => "RC", 'txt' => 'Recibo');
         $this->sicredi['H'] = array('abr' => "LC", 'txt' => 'Letra de Câmbio');
         $this->sicredi['I'] = array('abr' => "ND", 'txt' => 'Nota de Débito');
-        $this->sicredi['J'] = array('abr' => "TS", 'txt' => 'Triplicata de Serviço');
-        $this->sicredi['K'] = array('abr' => "DIV", 'txt' => 'Outros');
+        $this->sicredi['J'] = array('abr' => "DSI", 'txt' => 'Duplicata de Serviço por Indicação');
+        $this->sicredi['K'] = array('abr' => "OS", 'txt' => 'Outros');
 
         $this->santander[1] = array('abr' => "DM", 'txt' => 'Duplicata Mercantil');
         $this->santander[2] = array('abr' => "NP", 'txt' => 'Nota Promissória');


### PR DESCRIPTION
As duas últimas linhas das espécies foram ajustadas para ('abr' => "DSI", 'txt' => 'Duplicata de Serviço por Indicação') e ('abr' => "OS", 'txt' => 'Outros') conforme capítulo 3 do manual CNAB400 das Sicredi.