### PR TITLE
Ajuste do exemplo BB segundo campos mapeados no layout para B001 - Ba…

### DIFF
--- a/samples/ExemploRemessaBancoDoBrasil.php
+++ b/samples/ExemploRemessaBancoDoBrasil.php
@@ -102,10 +102,10 @@ $lote->inserirDetalhe(array(
 		'vlr_multa'         => 	'0000000000002.00', // Valor do juros de 2% ao mês
 
 		// Registro 3S3 Mensagens a serem impressas
-		'mensagem_sc_1' 	=> "Após venc. Mora 0,03%/dia e Multa 2,00%",
-		'mensagem_sc_2' 	=> "Não conceder desconto",
-		'mensagem_sc_3' 	=> "Sujeito a protesto após o vencimento",
-		'mensagem_sc_4' 	=> "VelvetTux Soluções em Sistemas <('')",
+		'mensagem_1' 	=> "Após venc. Mora 0,03%/dia e Multa 2,00%",
+		'mensagem_2' 	=> "Não conceder desconto",
+		'mensagem_3' 	=> "Sujeito a protesto após o vencimento",
+		'mensagem_4' 	=> "VelvetTux Soluções em Sistemas <('')",
 
 ));
 


### PR DESCRIPTION
…nco do Brasil

O formato atual não era considerado na remessa, pois o nome do campo estava errado, contendo esse _sc_