### PR TITLE
Update RetornoAbstract.php

### DIFF
--- a/src/RetornoAbstract.php
+++ b/src/RetornoAbstract.php
@@ -30,6 +30,8 @@ abstract class RetornoAbstract
      */
     public function __construct($conteudo)
     {
+        self::$loteCounter  = 1;
+        self::$linesCounter = 0;       
         $conteudo = str_replace("\r\n", "\n", $conteudo);
         $lines = explode("\n", $conteudo);
         if (count($lines) < 2) {


### PR DESCRIPTION
Correção para iniciar variáveis como Default
-Acontecia em caso de importação de 2 ou mais retorno(Lote) as variáveis ficam inicializadas com valores anteriores da última importação