### PR TITLE
Use of strpos instead of str_contains

### DIFF
--- a/src/RetornoAbstract.php
+++ b/src/RetornoAbstract.php
@@ -53,7 +53,7 @@ abstract class RetornoAbstract
             $codigo_banco = substr($lines[0], 76, 3);
             $codigo_tipo = substr($lines[0], 1, 1);
 
-            if (str_contains($lines[2], 'qrpix.bradesco.com.br')) {
+            if (strpos($lines[2], 'qrpix.bradesco.com.br') !== false) {
                 self::$pix = true;
             } else {
                 self::$pix = false;


### PR DESCRIPTION
str_contains is PHP8 exclusive while strpos is available from PHP4 and later.