### PR TITLE
Normaliza geração de remessa do cnab400 sicoob

### DIFF
--- a/src/Especie.php
+++ b/src/Especie.php
@@ -33,12 +33,13 @@ class Especie {
     private $itau = array();
     private $caixa = array();
     private $bb = array();
-    private $siccob = array();
+    private $sicoob = array();
     private $sicredi = array();
     private $bradesco = array();
     private $santander = array();
     private $c6bank = array();
     private $bv = array();
+    private $abc = array();
     private $banco;
 
     public function __construct($banco = null) {

--- a/src/RegistroRemAbstract.php
+++ b/src/RegistroRemAbstract.php
@@ -99,9 +99,9 @@ abstract class RegistroRemAbstract extends RegistroAbstract {
                     throw new Exception('Campo faltante ou com valor nulo:' . $prop);
                 }
             }
-            set_error_handler(function ($severity, $message, $file, $line,$errcontext) {
-                throw new \ErrorException(json_encode($errcontext)."->".$message, $severity, $severity, $file, $line);
-            });
+            // set_error_handler(function ($severity, $message, $file, $line,$errcontext) {
+            //     throw new \ErrorException(json_encode($errcontext)."->".$message, $severity, $severity, $file, $line);
+            // });
 
             switch ($metaData['tipo']) {
                 case 'decimal':

--- a/src/RemessaAbstract.php
+++ b/src/RemessaAbstract.php
@@ -115,7 +115,7 @@ abstract class RemessaAbstract {
             $child->getText();
         }
         $class = '\CnabPHP\resources\\B' . self::$banco . '\remessa\\' . self::$layout . '\Registro9';
-        $headerArquivo = new $class(array('1' => 1));
+        $headerArquivo = new $class(null);
         $headerArquivo->getText();
         return implode(self::$endLine, self::$retorno) . self::$endLine;
     }

--- a/src/RemessaAbstract.php
+++ b/src/RemessaAbstract.php
@@ -115,7 +115,7 @@ abstract class RemessaAbstract {
             $child->getText();
         }
         $class = '\CnabPHP\resources\\B' . self::$banco . '\remessa\\' . self::$layout . '\Registro9';
-        $headerArquivo = new $class(null);
+        $headerArquivo = new $class(array('1'=> 1));
         $headerArquivo->getText();
         return implode(self::$endLine, self::$retorno) . self::$endLine;
     }

--- a/src/resources/B756/remessa/cnab400/Registro1.php
+++ b/src/resources/B756/remessa/cnab400/Registro1.php
@@ -349,7 +349,7 @@ class Registro1 extends Generico1
                 $constante = 7;
                 $cont = 0;
             }
-            $calculoDv = $calculoDv + (substr($sequencia,$num,1) * $constante);
+            $calculoDv = $calculoDv + (intval(substr($sequencia,$num,1)) * $constante);
         }
 
         $Resto = $calculoDv % 11;


### PR DESCRIPTION
Erros múltiplos que impediam a geração da remessa.

Não consegui emular todos os bancos para avaliar o motivo desse parâmetro  existir, entretanto ele estava provocando um erro de index não encontrada.

[src/RemessaAbstract.php](https://github.com/QuilhaSoft/OpenCnabPHP/compare/master...Ctrl-Mota:OpenCnabPHP:master?expand=1#diff-b0c9134cc5ebf8bc4a5ffcf41c01820bd0c0847bd5ac4a0fb49b8adce2501a94)